### PR TITLE
Moved Precaching to OnMapStart(), closes sound issue in splewis/csgo-practice-mode#64

### DIFF
--- a/scripting/csutils.sp
+++ b/scripting/csutils.sp
@@ -38,14 +38,14 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 }
 
 public void OnPluginStart() {
-  PrecacheSound(SMOKE_EMIT_SOUND);
-
   g_OnGrenadeThrownForward = CreateGlobalForward(
       "CSU_OnThrowGrenade", ET_Ignore, Param_Cell, Param_Cell, Param_Cell,
       Param_Array, Param_Array, Param_Array,Param_Array);
 }
 
 public void OnMapStart() {
+  PrecacheSound(SMOKE_EMIT_SOUND);
+
   delete g_NadeList;
   g_NadeList = new ArrayList(8);
 


### PR DESCRIPTION
I went ahead and did some testing on multiple servers and machines after tagging Splewis last night, and went ahead and moved the Precaching to OnMapStart() as that is what I normally do in plugins and it functions as expected. This fixes the sound issue I listed in #64.