### PR TITLE
[Feature] MySQL Import/Export

### DIFF
--- a/scripting/practicemode.sp
+++ b/scripting/practicemode.sp
@@ -240,6 +240,7 @@ Handle g_OnPracticeModeSettingsRead = INVALID_HANDLE;
 #include "practicemode/grenade_filters.sp"
 #include "practicemode/grenade_menus.sp"
 #include "practicemode/grenade_utils.sp"
+#include "practicemode/grenade_mysql.sp"
 #include "practicemode/natives.sp"
 #include "practicemode/pugsetup_integration.sp"
 #include "practicemode/settings_menu.sp"
@@ -602,6 +603,12 @@ public void OnPluginStart() {
 
     RegConsoleCmd("sm_test_database", Command_TestDatabaseConnection);
     PM_AddChatAlias(".testdb", "sm_test_database");
+
+    RegConsoleCmd("sm_export_grenades_to_database", Command_ExportGrenadesToDatabase);
+    PM_AddChatAlias(".exportdb", "sm_export_grenades_to_database");
+
+    RegConsoleCmd("sm_import_grenades_from_database", Command_ImportGrenadesFromDatabase);
+    PM_AddChatAlias(".importdb", "sm_import_grenades_from_database");
   }
 
   // New Plugin cvars
@@ -1595,23 +1602,4 @@ public void CSU_OnThrowGrenade(int client, int entity, GrenadeType grenadeType, 
   g_LastGrenadeOrigin[client] = origin;
   g_LastGrenadeVelocity[client] = velocity;
   Replays_OnThrowGrenade(client, entity, grenadeType, origin, velocity);
-}
-
-public void GetDatabaseConnection() {
-  if (g_UseDatabaseCvar.IntValue == 0) {
-    return;
-  }
-
-  char error[255];
-  Database db = SQL_DefConnect(error, sizeof(error));
-   
-  if (db == null)
-  {
-    PrintToServer("Could not connect to 'default' database (sourcemod/config/database.cfg): %s", error);
-  } 
-  else 
-  {
-    PrintToServer("Connected to external database...");
-    g_Database = db;
-  }
 }

--- a/scripting/practicemode/commands.sp
+++ b/scripting/practicemode/commands.sp
@@ -586,3 +586,18 @@ public Action Command_Break(int client, int args) {
   PM_MessageToAll("Broke all breakable entities.");
   return Plugin_Handled;
 }
+
+public Action Command_TestDatabaseConnection(int client, int args) {
+  if (!g_InPracticeMode) {
+    return Plugin_Handled;
+  }
+
+  if (!GetCvarIntSafe("sm_practicemode_use_database")) {
+    PM_Message(client, ".testdb requires sm_practicemode_use_database to be enabled.");
+    return Plugin_Handled;
+  }
+
+  GetDatabaseConnection();
+
+  return Plugin_Handled;
+}

--- a/scripting/practicemode/commands.sp
+++ b/scripting/practicemode/commands.sp
@@ -592,7 +592,7 @@ public Action Command_TestDatabaseConnection(int client, int args) {
     return Plugin_Handled;
   }
 
-  if (!GetCvarIntSafe("sm_practicemode_use_database")) {
+  if (!g_UseDatabaseCvar.BoolValue) {
     PM_Message(client, "sm_test_database (.testdb) requires sm_practicemode_use_database to be enabled.");
     return Plugin_Handled;
   }
@@ -608,7 +608,7 @@ public Action Command_ExportGrenadesToDatabase(int client, int args) {
     return Plugin_Handled;
   }
 
-  if (!GetCvarIntSafe("sm_practicemode_use_database")) {
+  if (!g_UseDatabaseCvar.BoolValue) {
     PM_Message(client, "sm_export_grenades_to_database (.exportdb) requires sm_practicemode_use_database to be enabled.");
     return Plugin_Handled;
   }
@@ -632,7 +632,7 @@ public Action Command_ImportGrenadesFromDatabase(int client, int args) {
     return Plugin_Handled;
   }
 
-  if (!GetCvarIntSafe("sm_practicemode_use_database")) {
+  if (!g_UseDatabaseCvar.BoolValue) {
     PM_Message(client, "sm_import_grenades_from_database (.importdb) requires sm_practicemode_use_database to be enabled.");
     return Plugin_Handled;
   }

--- a/scripting/practicemode/commands.sp
+++ b/scripting/practicemode/commands.sp
@@ -593,11 +593,60 @@ public Action Command_TestDatabaseConnection(int client, int args) {
   }
 
   if (!GetCvarIntSafe("sm_practicemode_use_database")) {
-    PM_Message(client, ".testdb requires sm_practicemode_use_database to be enabled.");
+    PM_Message(client, "sm_test_database (.testdb) requires sm_practicemode_use_database to be enabled.");
     return Plugin_Handled;
   }
 
   GetDatabaseConnection();
+  CloseDatabaseConnection();
+
+  return Plugin_Handled;
+}
+
+public Action Command_ExportGrenadesToDatabase(int client, int args) {
+  if (!g_InPracticeMode) {
+    return Plugin_Handled;
+  }
+
+  if (!GetCvarIntSafe("sm_practicemode_use_database")) {
+    PM_Message(client, "sm_export_grenades_to_database (.exportdb) requires sm_practicemode_use_database to be enabled.");
+    return Plugin_Handled;
+  }
+
+  char tableName[PLATFORM_MAX_PATH];
+  if (args >= 1 && GetCmdArg(1, tableName, sizeof(tableName))) {
+    ExportGrenadesToDatabase(tableName);
+  } else {
+    //Set tableName to default if no argument provided.
+    char map[PLATFORM_MAX_PATH];
+    GetCleanMapName(map, sizeof(map));
+    Format(tableName, sizeof(tableName), "%s_grenades", map);
+    ExportGrenadesToDatabase(tableName);
+  }
+
+  return Plugin_Handled;
+}
+
+public Action Command_ImportGrenadesFromDatabase(int client, int args) {
+  if (!g_InPracticeMode) {
+    return Plugin_Handled;
+  }
+
+  if (!GetCvarIntSafe("sm_practicemode_use_database")) {
+    PM_Message(client, "sm_import_grenades_from_database (.importdb) requires sm_practicemode_use_database to be enabled.");
+    return Plugin_Handled;
+  }
+
+  char tableName[PLATFORM_MAX_PATH];
+  if (args >= 1 && GetCmdArg(1, tableName, sizeof(tableName))) {
+    ImportGrenadesFromDatabase(tableName);
+  } else {
+    //Set tableName to default if no argument provided.
+    char map[PLATFORM_MAX_PATH];
+    GetCleanMapName(map, sizeof(map));
+    Format(tableName, sizeof(tableName), "%s_grenades", map);
+    ImportGrenadesFromDatabase(tableName);
+  }
 
   return Plugin_Handled;
 }

--- a/scripting/practicemode/grenade_iterators.sp
+++ b/scripting/practicemode/grenade_iterators.sp
@@ -7,7 +7,7 @@ typedef GrenadeIteratorFunction = function Action(
 // TODO: this should be able to modify the grenade strings as well,
 // so name, description, and grenadeId shouldn't be const.
 // For now only 'origin' and 'angles' can be updated.
-// TODO: this shoudl also just pass the category string, and a good helper function should be
+// TODO: this should also just pass the category string, and a good helper function should be
 // available to convert it to an ArrayList.
 stock void IterateGrenades(GrenadeIteratorFunction f, any data = 0) {
   char ownerName[MAX_NAME_LENGTH];

--- a/scripting/practicemode/grenade_mysql.sp
+++ b/scripting/practicemode/grenade_mysql.sp
@@ -1,5 +1,5 @@
 public void GetDatabaseConnection() {
-  if (g_UseDatabaseCvar.IntValue == 0) {
+  if (!g_UseDatabaseCvar.BoolValue) {
     return;
   }
 
@@ -18,7 +18,7 @@ public void GetDatabaseConnection() {
 }
 
 public void CloseDatabaseConnection() {
-  if (g_UseDatabaseCvar.IntValue == 0 || g_Database == null) {
+  if (!g_UseDatabaseCvar.BoolValue || g_Database == null) {
     return;
   }
 
@@ -29,7 +29,7 @@ public void CloseDatabaseConnection() {
 }
 
 public void ExportGrenadesToDatabase(const char[] tableName) {
-  if (!g_InPracticeMode || g_UseDatabaseCvar.IntValue == 0 ) {
+  if (!g_InPracticeMode || !g_UseDatabaseCvar.BoolValue ) {
     return;
   }
 
@@ -177,7 +177,7 @@ DBStatement selectUsersQuery = null;
 public bool ImportGrenadesFromDatabase(const char[] tableName)
 {
 
-  if (!g_InPracticeMode || g_UseDatabaseCvar.IntValue == 0 ) {
+  if (!g_InPracticeMode || !g_UseDatabaseCvar.BoolValue ) {
     return false;
   }
 

--- a/scripting/practicemode/grenade_mysql.sp
+++ b/scripting/practicemode/grenade_mysql.sp
@@ -1,0 +1,264 @@
+public void GetDatabaseConnection() {
+  if (g_UseDatabaseCvar.IntValue == 0) {
+    return;
+  }
+
+  char error[255];
+  Database db = SQL_DefConnect(error, sizeof(error));
+   
+  if (db == null)
+  {
+    PrintToServer("Could not connect to 'default' database (sourcemod/config/database.cfg): %s", error);
+  } 
+  else 
+  {
+    PrintToServer("Connected to external database...");
+    g_Database = db;
+  }
+}
+
+public void CloseDatabaseConnection() {
+  if (g_UseDatabaseCvar.IntValue == 0 || g_Database == null) {
+    return;
+  }
+
+  PrintToServer("Closed connection to external database...");
+
+  g_Database = null;
+
+}
+
+public void ExportGrenadesToDatabase(const char[] tableName) {
+  if (!g_InPracticeMode || g_UseDatabaseCvar.IntValue == 0 ) {
+    return;
+  }
+
+  if (g_Database == null) {
+    GetDatabaseConnection();
+  }
+  
+  char steamId[255];
+  char steamName[255];
+  char grenadeId[12];
+  char name[255];
+  char origin[255];
+  char angles[255];
+  char grenadeType[255];
+  char grenadeOrigin[255];
+  char grenadeVelocity[255];
+  char description[255];
+  char categories[GRENADE_CATEGORY_LENGTH];
+
+  char query[1000];
+  int buffer_len = strlen(tableName) * 2 + 1;
+  char[] new_map = new char[buffer_len];
+
+  SQL_EscapeString(g_Database, tableName, new_map, buffer_len);
+
+  Format(query, sizeof(query), "CREATE TABLE IF NOT EXISTS `%s` ("
+    ... "`id` int(4) NOT NULL AUTO_INCREMENT,"
+    ... "`steamId` varchar(128) DEFAULT NULL,"
+    ... "`steamName` varchar(128) DEFAULT NULL,"
+    ... "`grenadeId` int(4) NOT NULL,"
+    ... "`name` varchar(128) DEFAULT NULL,"
+    ... "`categories` varchar(128) DEFAULT NULL,"
+    ... "`origin` varchar(128) DEFAULT NULL,"
+    ... "`angles` varchar(128) DEFAULT NULL,"
+    ... "`grenadeType` varchar(128) DEFAULT NULL,"
+    ... "`grenadeOrigin` varchar(128) DEFAULT NULL,"
+    ... "`grenadeVelocity` varchar(128) DEFAULT NULL,"
+    ... "`description` varchar(256) DEFAULT NULL,"
+    ... "`timestamp` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,"
+    ... "PRIMARY KEY (`grenadeId`),"
+    ... "KEY `id` (`id`))", tableName);
+
+  if (!SQL_FastQuery(g_Database, query)) {
+    char error[255];
+    SQL_GetError(g_Database, error, sizeof(error));
+    PrintToServer("Failed to create table for %s (error: %s)", tableName, error);
+  }
+
+  //Begin massive looping
+  g_GrenadeLocationsKv.Rewind();
+  g_GrenadeLocationsKv.GotoFirstSubKey(false);
+
+  int userCount = 0;
+  do 
+  {
+    userCount += 1;
+    g_GrenadeLocationsKv.GetSectionName(steamId, sizeof(steamId));
+    g_GrenadeLocationsKv.GetString("name", steamName, sizeof(steamName));
+    if (g_GrenadeLocationsKv.GotoFirstSubKey(false)) {
+      g_GrenadeLocationsKv.GotoNextKey(false);
+      int grenadeCount = 0;
+      do
+      {
+        grenadeCount += 1;
+        g_GrenadeLocationsKv.GetSectionName(grenadeId, sizeof(grenadeId));
+        g_GrenadeLocationsKv.GetString("name", name, sizeof(name));
+        g_GrenadeLocationsKv.GetString("categories", categories, sizeof(categories));
+        g_GrenadeLocationsKv.GetString("origin", origin, sizeof(origin));
+        g_GrenadeLocationsKv.GetString("angles", angles, sizeof(angles));
+        g_GrenadeLocationsKv.GetString("grenadeType", grenadeType, sizeof(grenadeType));
+        g_GrenadeLocationsKv.GetString("grenadeOrigin", grenadeOrigin, sizeof(grenadeOrigin));
+        g_GrenadeLocationsKv.GetString("grenadeVelocity", grenadeVelocity, sizeof(grenadeVelocity));
+        g_GrenadeLocationsKv.GetString("description", description, sizeof(description));
+        //$$$ Big money function right here $$$
+        UpsertGrenade(tableName, steamId, steamName, StringToInt(grenadeId), name, categories, origin, angles, grenadeType, grenadeOrigin, grenadeVelocity, description);
+      } while (g_GrenadeLocationsKv.GotoNextKey(false));
+      PrintToServer("%i grenades by %s (%s) were exported.", grenadeCount, steamName, steamId);
+    }
+
+    g_GrenadeLocationsKv.GoBack();
+  } while (g_GrenadeLocationsKv.GotoNextKey(false));
+  PrintToServer("%i users were iterated.", userCount);
+
+  CloseDatabaseConnection();
+
+}
+
+DBStatement exportQuery = null;
+//Upsert = atomically either insert a row, or on the basis of the row already existing, UPDATE that existing row instead
+static void UpsertGrenade(const char[] tableName, const char[] steamId, const char[] steamName, int grenadeId, const char[] name, const char[] categories, const char[] origin, const char[] angles, 
+  const char[] grenadeType, const char[] grenadeOrigin, const char[] grenadeVelocity, const char[] description ) {
+  if (g_Database == null) {
+    PrintToServer("No database connection open.");
+    return;
+  }
+
+  char error[255];
+  char query[5000];
+
+  Format(query, sizeof(query), "INSERT INTO %s ("
+    ... "steamId, steamName, grenadeId, name, categories, origin, angles, grenadeType, grenadeOrigin, grenadeVelocity, description"
+    ... ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE steamId = ?, steamName = ?, grenadeId = ?, name = ?, categories = ?, origin = ?, angles = ?, grenadeType = ?, "
+    ... "grenadeOrigin = ?, grenadeVelocity = ?, description = ?;", tableName);
+  //PrintToServer(query);
+  if (exportQuery == null) {
+    exportQuery = SQL_PrepareQuery(g_Database, query, error, sizeof(error));
+    if (exportQuery == null) {
+      PrintToServer("Failed to prepare export query (error: %s)", error);
+    }
+  }
+
+  //PrintToServer("(%s, %s, %i, %s, %s, %s, %s, %s, %s, %s)", steamId, steamName, StringToInt(grenadeId), name, origin, angles, grenadeType, grenadeOrigin, grenadeVelocity, description );
+  //PrintToServer("(steamId = %s, steamName = %s, grenadeId = %i, name = %s, origin = %s, angles = %s, grenadeType = %s, grenadeOrigin = %s, grenadeVelocity = %s, description = %s)", steamId, steamName, grenadeId, name, origin, angles, grenadeType, grenadeOrigin, grenadeVelocity, description );
+
+
+  //22 params to bind starting at index 0
+  //We prepare and bind everything because SQL injection isn't fun.
+  SQL_BindParamString(exportQuery, 0, steamId, false);
+  SQL_BindParamString(exportQuery, 1, steamName, false);
+  SQL_BindParamInt(exportQuery, 2, grenadeId, false);
+  SQL_BindParamString(exportQuery, 3, name, false);
+  SQL_BindParamString(exportQuery, 4, categories, false);
+  SQL_BindParamString(exportQuery, 5, origin, false);
+  SQL_BindParamString(exportQuery, 6, angles, false);
+  SQL_BindParamString(exportQuery, 7, grenadeType, false);
+  SQL_BindParamString(exportQuery, 8, grenadeOrigin, false);
+  SQL_BindParamString(exportQuery, 9, grenadeVelocity, false);
+  SQL_BindParamString(exportQuery, 10, description, false);
+  SQL_BindParamString(exportQuery, 11, steamId, false);
+  SQL_BindParamString(exportQuery, 12, steamName, false);
+  SQL_BindParamInt(exportQuery, 13, grenadeId, false);
+  SQL_BindParamString(exportQuery, 14, name, false);
+  SQL_BindParamString(exportQuery, 15, categories, false);
+  SQL_BindParamString(exportQuery, 16, origin, false);
+  SQL_BindParamString(exportQuery, 17, angles, false);
+  SQL_BindParamString(exportQuery, 18, grenadeType, false);
+  SQL_BindParamString(exportQuery, 19, grenadeOrigin, false);
+  SQL_BindParamString(exportQuery, 20, grenadeVelocity, false);
+  SQL_BindParamString(exportQuery, 21, description, false);
+
+  if (!SQL_Execute(exportQuery))
+  {
+    SQL_GetError(g_Database, error, sizeof(error));
+    PrintToServer("Failed to execute export SQL (error: %s)", error);
+  }
+
+}
+
+DBStatement selectUsersQuery = null;
+public bool ImportGrenadesFromDatabase(const char[] tableName)
+{
+
+  if (!g_InPracticeMode || g_UseDatabaseCvar.IntValue == 0 ) {
+    return false;
+  }
+
+  if (g_Database == null) {
+    GetDatabaseConnection();
+  }
+
+  //if (g_Database == null) {
+  //  PrintToServer("No database connection open.");
+  //  return false;
+  //}
+  char query[255];
+  Format(query, sizeof(query), "SELECT * FROM %s;", tableName);
+
+  if (selectUsersQuery == null)
+  {
+    char error[255];
+    if ((selectUsersQuery = SQL_PrepareQuery(g_Database, 
+      query, 
+      error, 
+      sizeof(error))) 
+         == null)
+    {
+      PrintToServer("Failed to prepare export query (error: %s)", error);
+      CloseDatabaseConnection();
+      return false;
+    }
+  }
+ 
+  //SQL_BindParamString(selectUsersQuery, 0, tableName, false);
+  if (!SQL_Execute(selectUsersQuery))
+  {
+    PrintToServer("Failed to execute query.");
+    CloseDatabaseConnection();
+    return false;
+  }
+ 
+  char steamId[255];
+  char steamName[255];
+  char grenadeId[12];
+  char name[255];
+  char categories[GRENADE_CATEGORY_LENGTH];
+  char origin[255];
+  char angles[255];
+  char grenadeType[255];
+  char grenadeOrigin[255];
+  char grenadeVelocity[255];
+  char description[255];
+
+  if (SQL_GetRowCount(selectUsersQuery) < 1) {
+    PrintToServer("Nothing to import from table: %s...", tableName);
+    return false;
+  }
+
+  PrintToServer("Retrieved %i grenades to import...", SQL_GetRowCount(selectUsersQuery));
+
+  while (SQL_FetchRow(selectUsersQuery))
+  {
+    int dbId = SQL_FetchInt(selectUsersQuery, 0);
+    SQL_FetchString(selectUsersQuery, 1, steamId, sizeof(name));
+    SQL_FetchString(selectUsersQuery, 2, steamName, sizeof(steamName));
+    SQL_FetchString(selectUsersQuery, 3, grenadeId, sizeof(grenadeId));
+    SQL_FetchString(selectUsersQuery, 4, name, sizeof(name));
+    SQL_FetchString(selectUsersQuery, 5, categories, sizeof(categories));
+    SQL_FetchString(selectUsersQuery, 6, origin, sizeof(origin));
+    SQL_FetchString(selectUsersQuery, 7, angles, sizeof(angles));
+    SQL_FetchString(selectUsersQuery, 8, grenadeType, sizeof(grenadeType));
+    SQL_FetchString(selectUsersQuery, 9, grenadeOrigin, sizeof(grenadeOrigin));
+    SQL_FetchString(selectUsersQuery, 10, grenadeVelocity, sizeof(grenadeVelocity));
+    SQL_FetchString(selectUsersQuery, 11, description, sizeof(description));
+    SaveGrenadeFromDatabase(grenadeId, steamId, steamName, origin, angles, grenadeOrigin, grenadeVelocity, grenadeType, name, description, categories);
+    PrintToServer("Imported dbId => %i, name => %s", dbId, name);
+  }
+
+  CloseDatabaseConnection();
+  return true;
+}
+
+

--- a/scripting/practicemode/grenade_utils.sp
+++ b/scripting/practicemode/grenade_utils.sp
@@ -265,9 +265,6 @@ stock int SaveGrenadeFromDatabase(const char[] idStr, const char[] auth,
     gOrigin[0] = StringToFloat(num[0]);
     gOrigin[1] = StringToFloat(num[1]);
     gOrigin[2] = StringToFloat(num[2]);
-    //PrintToServer("%s = grenadeOrigin", grenadeOrigin);
-    //PrintToServer("%s, %s, %s", num[0], num[1], num[2]);
-    //PrintToServer("%.6f, %.6f, %.6f", gOrigin[0], gOrigin[1], gOrigin[2]);
     g_GrenadeLocationsKv.SetVector("grenadeOrigin", gOrigin);
   }
 

--- a/scripting/practicemode/grenade_utils.sp
+++ b/scripting/practicemode/grenade_utils.sp
@@ -224,6 +224,72 @@ stock int SaveGrenadeToKv(int client, const float origin[3], const float angles[
   return g_NextID - 1;
 }
 
+stock int SaveGrenadeFromDatabase(const char[] idStr, const char[] auth, 
+                                  const char[] clientName, const char[] origin, const char[] angles,
+                                  const char[] grenadeOrigin = "", const char[] grenadeVelocity = "",
+                                  const char[] grenadeTypeString, const char[] name, const char[] description = "",
+                                  const char[] categoryString = "") {
+
+  g_UpdatedGrenadeKv = true;
+
+  g_GrenadeLocationsKv.JumpToKey(auth, true);
+  g_GrenadeLocationsKv.SetString("name", clientName);
+
+  g_GrenadeLocationsKv.JumpToKey(idStr, true);
+
+  g_GrenadeLocationsKv.SetString("name", name);
+
+  char num[3][PLATFORM_MAX_PATH];
+  float pOrigin[3];
+  float pAngles[3]; 
+
+  ExplodeString(origin, " ", num, sizeof(num), PLATFORM_MAX_PATH);
+  pOrigin[0] = StringToFloat(num[0]);
+  pOrigin[1] = StringToFloat(num[1]);
+  pOrigin[2] = StringToFloat(num[2]);
+  g_GrenadeLocationsKv.SetVector("origin", pOrigin);
+
+  ExplodeString(angles, " ", num, sizeof(num), PLATFORM_MAX_PATH);
+  pAngles[0] = StringToFloat(num[0]);
+  pAngles[1] = StringToFloat(num[1]);
+  pAngles[2] = StringToFloat(num[2]);
+  g_GrenadeLocationsKv.SetVector("angles", pAngles);
+  
+  if (!StrEqual(grenadeTypeString, "")) {
+    g_GrenadeLocationsKv.SetString("grenadeType", grenadeTypeString);
+  }
+
+  if (!StrEqual(grenadeOrigin, "")) {
+    float gOrigin[3];
+    ExplodeString(grenadeOrigin, " ", num, sizeof(num), PLATFORM_MAX_PATH);
+    gOrigin[0] = StringToFloat(num[0]);
+    gOrigin[1] = StringToFloat(num[1]);
+    gOrigin[2] = StringToFloat(num[2]);
+    //PrintToServer("%s = grenadeOrigin", grenadeOrigin);
+    //PrintToServer("%s, %s, %s", num[0], num[1], num[2]);
+    //PrintToServer("%.6f, %.6f, %.6f", gOrigin[0], gOrigin[1], gOrigin[2]);
+    g_GrenadeLocationsKv.SetVector("grenadeOrigin", gOrigin);
+  }
+
+  if (!StrEqual(grenadeVelocity, "")) {
+    float gVelocity[3];
+    ExplodeString(grenadeVelocity, " ", num, sizeof(num), PLATFORM_MAX_PATH);
+    gVelocity[0] = StringToFloat(num[0]);
+    gVelocity[1] = StringToFloat(num[1]);
+    gVelocity[2] = StringToFloat(num[2]);
+    g_GrenadeLocationsKv.SetVector("grenadeVelocity", gVelocity);
+  }
+
+  g_GrenadeLocationsKv.SetString("description", description);
+  g_GrenadeLocationsKv.SetString("categories", categoryString);
+
+  g_GrenadeLocationsKv.GoBack();
+  g_GrenadeLocationsKv.GoBack();
+  g_NextID = StringToInt(idStr);
+  g_NextID++;
+  return g_NextID - 1;
+}
+
 public bool DeleteGrenadeFromKv(const char[] nadeIdStr) {
   g_UpdatedGrenadeKv = true;
   char auth[AUTH_LENGTH];

--- a/scripting/practicemode/util.sp
+++ b/scripting/practicemode/util.sp
@@ -5,7 +5,7 @@
 
 #tryinclude "manual_version.sp"
 #if !defined PLUGIN_VERSION
-#define PLUGIN_VERSION "1.3.5-dev"
+#define PLUGIN_VERSION "1.3.4-dev"
 #endif
 
 static char _colorNames[][] = {"{NORMAL}", "{DARK_RED}",    "{PINK}",      "{GREEN}",

--- a/scripting/practicemode/util.sp
+++ b/scripting/practicemode/util.sp
@@ -5,7 +5,7 @@
 
 #tryinclude "manual_version.sp"
 #if !defined PLUGIN_VERSION
-#define PLUGIN_VERSION "1.3.4-dev"
+#define PLUGIN_VERSION "1.3.5-dev"
 #endif
 
 static char _colorNames[][] = {"{NORMAL}", "{DARK_RED}",    "{PINK}",      "{GREEN}",


### PR DESCRIPTION
This PR includes basic exporting and importing to the default configured MySQL connection as referenced in the SourceMod docs: https://wiki.alliedmods.net/SQL_(SourceMod_Scripting)#Connecting

The goal is to provide and easy way to share grenade data with external sources.

### New CVar
- ``sm_praceticemode_use_database <1/0>``: enables database commands

### New Commands
- ``.testdb``: tests your MySQL connection settings
- `` .exportdb <optional table name>``: exports all the current map's grenades to a table, will overwrite duplicates on the same ID
- ``.importdb <optional table name>``: imports and **overwrites** grenades on the current map

#### Notes
- *``.importdb`` is dangerous and overwrites grenades* 
- *Default table names look like ``<map name>_grenades``*

Please let me know your suggestions!