### PR TITLE
add AND and OR filters with '&' and '|' respectively

### DIFF
--- a/scripting/practicemode.sp
+++ b/scripting/practicemode.sp
@@ -179,6 +179,7 @@ enum GrenadeMenuType {
   GrenadeMenuType_OneCategory = 3,  // Note: empty category "" = all nades.
   GrenadeMenuType_MatchingName = 4,
   GrenadeMenuType_MatchingId = 5,
+  GrenadeMenuType_MultiCategory = 6,
 };
 
 // All the data we need to call GiveGrenadeMenu for a client to reopen the .nades menu


### PR DESCRIPTION
fixes #123 

Hi, I took a stab at implementing this today. I have it running on my prac server and it seems to be working fine for us. It works for `.nades` and `.throw` and probably anything else that uses the FindGrenades function.