### PR TITLE
feat: add new cvar to not open setup menu on start

### DIFF
--- a/scripting/practicemode.sp
+++ b/scripting/practicemode.sp
@@ -57,6 +57,7 @@ ConVar g_BotRespawnTimeCvar;
 ConVar g_DryRunFreezeTimeCvar;
 ConVar g_MaxGrenadesSavedCvar;
 ConVar g_MaxHistorySizeCvar;
+ConVar g_OpenMenuOnStart;
 ConVar g_PracModeCanBeStartedCvar;
 ConVar g_SharedAllNadesCvar;
 ConVar g_FastfowardRequiresZeroVolumeCvar;
@@ -630,6 +631,8 @@ public void OnPluginStart() {
   g_MaxGrenadesSavedCvar = CreateConVar(
       "sm_practicemode_max_grenades_saved", "512",
       "Maximum number of grenades that may be saved per-map, per-client. Set to 0 to disable.");
+  g_OpenMenuOnStart =
+      CreateConVar("sm_practicemode_menu_on_start", "1", "Whether to open setup menu when starting practicemode");
   g_PracModeCanBeStartedCvar =
       CreateConVar("sm_practicemode_can_be_started", "1", "Whether practicemode may be started");
   g_SharedAllNadesCvar = CreateConVar(

--- a/scripting/practicemode/commands.sp
+++ b/scripting/practicemode/commands.sp
@@ -10,7 +10,9 @@ public Action Command_LaunchPracticeMode(int client, int args) {
     }
     LaunchPracticeMode();
     if (IsPlayer(client)) {
-      GivePracticeMenu(client);
+      if (g_OpenMenuOnStart.IntValue == 1) {
+        GivePracticeMenu(client);
+      }
     }
   }
   return Plugin_Handled;


### PR DESCRIPTION
Add a CVAR to not open the setup menu when starting practicemode
`sm_practicemode_menu_on_start` defaults to `1`

It's just a tedious thing to close the menu every time you start practicemode when you don't need/want to change any settings.