### PR TITLE
feat(commands): add individual rethrow commands

### DIFF
--- a/scripting/practicemode.sp
+++ b/scripting/practicemode.sp
@@ -125,6 +125,10 @@ GrenadeType g_LastGrenadeType[MAXPLAYERS + 1];
 float g_LastGrenadeOrigin[MAXPLAYERS + 1][3];
 float g_LastGrenadeVelocity[MAXPLAYERS + 1][3];
 
+bool g_LastGrenadeByTypeThrown[MAXPLAYERS + 1][GrenadeType];
+float g_LastGrenadeByTypeOrigin[MAXPLAYERS + 1][GrenadeType][3];
+float g_LastGrenadeByTypeVelocity[MAXPLAYERS + 1][GrenadeType][3];
+
 // Respawn values set by clients in the current session
 bool g_SavedRespawnActive[MAXPLAYERS + 1];
 float g_SavedRespawnOrigin[MAXPLAYERS + 1][3];
@@ -378,6 +382,24 @@ public void OnPluginStart() {
     RegConsoleCmd("sm_throw", Command_Throw);
     PM_AddChatAlias(".throw", "sm_throw");
     PM_AddChatAlias(".rethrow", "sm_throw");
+
+    RegConsoleCmd("sm_throwsmoke", Command_ThrowSmoke);
+    PM_AddChatAlias(".throwsmoke", "sm_throwsmoke");
+    PM_AddChatAlias(".resmoke", "sm_throwsmoke");
+
+    RegConsoleCmd("sm_throwflash", Command_ThrowFlash);
+    PM_AddChatAlias(".throwflash", "sm_throwflash");
+    PM_AddChatAlias(".reflash", "sm_throwflash");
+
+    RegConsoleCmd("sm_throwmolotov", Command_ThrowMolotov);
+    PM_AddChatAlias(".throwmolotov", "sm_throwmolotov");
+    PM_AddChatAlias(".remolotov", "sm_throwmolotov");
+    PM_AddChatAlias(".remolly", "sm_throwmolotov");
+
+    RegConsoleCmd("sm_throwhenade", Command_ThrowHENade);
+    PM_AddChatAlias(".thrownade", "sm_throwhenade");
+    PM_AddChatAlias(".renade", "sm_throwhenade");
+    PM_AddChatAlias(".rehe", "sm_throwhenade");
   }
 
   // Bot commands
@@ -1631,5 +1653,10 @@ public void CSU_OnThrowGrenade(int client, int entity, GrenadeType grenadeType, 
   g_LastGrenadeType[client] = grenadeType;
   g_LastGrenadeOrigin[client] = origin;
   g_LastGrenadeVelocity[client] = velocity;
+
+  g_LastGrenadeByTypeThrown[client][grenadeType] = true;
+  g_LastGrenadeByTypeOrigin[client][grenadeType] = origin;
+  g_LastGrenadeByTypeVelocity[client][grenadeType] = velocity;
+
   Replays_OnThrowGrenade(client, entity, grenadeType, origin, velocity);
 }

--- a/scripting/practicemode/grenade_commands.sp
+++ b/scripting/practicemode/grenade_commands.sp
@@ -570,6 +570,97 @@ public Action Command_Throw(int client, int args) {
   return Plugin_Handled;
 }
 
+public Action Command_ThrowSmoke(int client, int args) {
+  if (!g_InPracticeMode) {
+    return Plugin_Handled;
+  }
+
+  if (!g_CSUtilsLoaded) {
+    PM_Message(client, "You need the csutils plugin installed to use that command.");
+    return Plugin_Handled;
+  }
+
+  if (g_LastGrenadeByTypeThrown[client][GrenadeType_Smoke]) {
+    PM_Message(client, "Throwing your last smoke.");
+    CSU_ThrowGrenade(client, GrenadeType_Smoke, g_LastGrenadeByTypeOrigin[client][GrenadeType_Smoke],
+                      g_LastGrenadeByTypeVelocity[client][GrenadeType_Smoke]);
+  } else {
+    PM_Message(client, "Can't throw you last smoke; you haven't thrown any!");
+  }
+
+  return Plugin_Handled;
+}
+
+public Action Command_ThrowFlash(int client, int args) {
+  if (!g_InPracticeMode) {
+    return Plugin_Handled;
+  }
+
+  if (!g_CSUtilsLoaded) {
+    PM_Message(client, "You need the csutils plugin installed to use that command.");
+    return Plugin_Handled;
+  }
+
+  if (g_LastGrenadeByTypeThrown[client][GrenadeType_Flash]) {
+    PM_Message(client, "Throwing your last flash.");
+    CSU_ThrowGrenade(client, GrenadeType_Flash, g_LastGrenadeByTypeOrigin[client][GrenadeType_Flash],
+                      g_LastGrenadeByTypeVelocity[client][GrenadeType_Flash]);
+  } else {
+    PM_Message(client, "Can't throw you last flash; you haven't thrown any!");
+  }
+
+  return Plugin_Handled;
+}
+
+public Action Command_ThrowMolotov(int client, int args) {
+  if (!g_InPracticeMode) {
+    return Plugin_Handled;
+  }
+
+  if (!g_CSUtilsLoaded) {
+    PM_Message(client, "You need the csutils plugin installed to use that command.");
+    return Plugin_Handled;
+  }
+
+  GrenadeType mollyType = GrenadeType_Molotov;
+  int team = GetClientTeam(client);
+
+  if (team == 3) {
+    mollyType = GrenadeType_Incendiary;
+  }
+
+  if (g_LastGrenadeByTypeThrown[client][mollyType]) {
+    PM_Message(client, "Throwing your last molotov.");
+    CSU_ThrowGrenade(client, mollyType, g_LastGrenadeByTypeOrigin[client][mollyType],
+                      g_LastGrenadeByTypeVelocity[client][mollyType]);
+  } else {
+    PM_Message(client, "Can't throw you last molotov; you haven't thrown any!");
+  }
+
+  return Plugin_Handled;
+}
+
+public Action Command_ThrowHENade(int client, int args) {
+  if (!g_InPracticeMode) {
+    return Plugin_Handled;
+  }
+
+  if (!g_CSUtilsLoaded) {
+    PM_Message(client, "You need the csutils plugin installed to use that command.");
+    return Plugin_Handled;
+  }
+
+  if (g_LastGrenadeByTypeThrown[client][GrenadeType_HE]) {
+    PM_Message(client, "Throwing your last HE grenade.");
+    CSU_ThrowGrenade(client, GrenadeType_HE, g_LastGrenadeByTypeOrigin[client][GrenadeType_HE],
+                      g_LastGrenadeByTypeVelocity[client][GrenadeType_HE]);
+  } else {
+    PM_Message(client, "Can't throw you last HE grenade; you haven't thrown any!");
+  }
+
+  return Plugin_Handled;
+}
+
 public Action Command_TestFlash(int client, int args) {
   if (!g_InPracticeMode) {
     return Plugin_Handled;


### PR DESCRIPTION
Add individual commands to rethrow specific grenades. Allows you to throw nade combo and then rethrow them without having to save them.