### PR TITLE
fix(*): correct all syntax errors

### DIFF
--- a/scripting/practicemode.sp
+++ b/scripting/practicemode.sp
@@ -1105,6 +1105,8 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
   if (g_AllowNoclipCvar.IntValue != 0 && StrEqual(text, ".noclip") && IsPlayer(client)) {
     PerformNoclipAction(client);
   }
+
+  return Plugin_Handled;
 }
 
 public void PerformNoclipAction(int client) {
@@ -1375,11 +1377,12 @@ public void OnEntityCreated(int entity, const char[] className) {
 // the owner is set by the time practicemode gets to the grenade.
 public int OnEntitySpawned(int entity) {
   RequestFrame(DelayedOnEntitySpawned, entity);
+  return 0;
 }
 
 public int DelayedOnEntitySpawned(int entity) {
   if (!IsValidEdict(entity)) {
-    return;
+    return 0;
   }
 
   char className[CLASS_LENGTH];
@@ -1441,6 +1444,8 @@ public int DelayedOnEntitySpawned(int entity) {
       }
     }
   }
+
+  return 0;
 }
 
 public Action Timer_TeleportClient(Handle timer, int serial) {
@@ -1450,6 +1455,8 @@ public Action Timer_TeleportClient(Handle timer, int serial) {
     TeleportEntity(client, g_TestingFlashOrigins[client], g_TestingFlashAngles[client], velocity);
     SetEntityMoveType(client, MOVETYPE_NONE);
   }
+
+  return Plugin_Handled;
 }
 
 public Action Timer_FakeGrenadeBack(Handle timer, int serial) {
@@ -1457,11 +1464,13 @@ public Action Timer_FakeGrenadeBack(Handle timer, int serial) {
   if (g_InPracticeMode && IsPlayer(client)) {
     FakeClientCommand(client, "sm_lastgrenade");
   }
+
+  return Plugin_Handled;
 }
 
 public Action Event_WeaponFired(Event event, const char[] name, bool dontBroadcast) {
   if (!g_InPracticeMode) {
-    return;
+    return Plugin_Handled;
   }
 
   int userid = event.GetInt("userid");
@@ -1472,13 +1481,17 @@ public Action Event_WeaponFired(Event event, const char[] name, bool dontBroadca
   if (IsGrenadeWeapon(weapon) && IsPlayer(client)) {
     AddGrenadeToHistory(client);
   }
+
+  return Plugin_Handled;
 }
 
 public Action Event_SmokeDetonate(Event event, const char[] name, bool dontBroadcast) {
   if (!g_InPracticeMode) {
-    return;
+    return Plugin_Handled;
   }
   GrenadeDetonateTimerHelper(event, "smoke grenade");
+
+  return Plugin_Handled;
 }
 
 public void GrenadeDetonateTimerHelper(Event event, const char[] grenadeName) {
@@ -1503,7 +1516,7 @@ public void GrenadeDetonateTimerHelper(Event event, const char[] grenadeName) {
 
 public Action Event_FlashDetonate(Event event, const char[] name, bool dontBroadcast) {
   if (!g_InPracticeMode) {
-    return;
+    return Plugin_Handled;
   }
 
   int userid = event.GetInt("userid");
@@ -1515,6 +1528,8 @@ public Action Event_FlashDetonate(Event event, const char[] name, bool dontBroad
   }
 
   g_LastFlashDetonateTime[client] = GetGameTime();
+
+  return Plugin_Handled;
 }
 
 public void GetTestingFlashInfo(int serial) {

--- a/scripting/practicemode/botreplay_data.sp
+++ b/scripting/practicemode/botreplay_data.sp
@@ -48,6 +48,8 @@ public int ReplaysMenuHandler(Menu menu, MenuAction action, int param1, int para
   } else if (action == MenuAction_End) {
     delete menu;
   }
+
+  return 0;
 }
 
 public void MaybeWriteNewReplayData() {

--- a/scripting/practicemode/botreplay_utils.sp
+++ b/scripting/practicemode/botreplay_utils.sp
@@ -183,7 +183,7 @@ stock bool IsReplayPlaying(int role = -1) {
 public void GotoReplayStart(int client, const char[] id, int role) {
   char filepath[PLATFORM_MAX_PATH + 1];
   GetRoleFile(id, role, filepath, sizeof(filepath));
-  int header[BMFileHeader];
+  BMFileHeader header;
   BMError error = BotMimic_GetFileHeaders(filepath, header, sizeof(header));
   if (error != BM_NoError) {
     char errorString[128];
@@ -195,16 +195,16 @@ public void GotoReplayStart(int client, const char[] id, int role) {
   float origin[3];
   float angles[3];
   float velocity[3];
-  Array_Copy(header[BMFH_initialPosition], origin, 3);
-  Array_Copy(header[BMFH_initialAngles], angles, 3);
+  Array_Copy(header.BMFH_initialPosition, origin, 3);
+  Array_Copy(header.BMFH_initialAngles, angles, 3);
   TeleportEntity(client, origin, angles, velocity);
 }
 
 // Functions to add a replay nade during a recording session to the practicemode-extra data
 // saved with replays.
-public void AddReplayNade(int client, GrenadeType type, float delay, const float[3] personOrigin,
-                   const float[3] personAngles, const float[3] grenadeOrigin,
-                   const float[3] grenadeVelocity) {
+public void AddReplayNade(int client, GrenadeType type, float delay, const float personOrigin[3],
+                   const float personAngles[3], const float grenadeOrigin[3],
+                   const float grenadeVelocity[3]) {
   int index = g_NadeReplayData[client].Push(type);
   g_NadeReplayData[client].Set(index, view_as<int>(delay), 1);
   g_NadeReplayData[client].Set(index, view_as<int>(personOrigin[0]), 2);

--- a/scripting/practicemode/bots.sp
+++ b/scripting/practicemode/bots.sp
@@ -51,6 +51,8 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
   if (IsPMBot(victim)) {
     g_BotDeathTime[victim] = GetGameTime();
   }
+
+  return Plugin_Handled;
 }
 
 public Action Timer_RespawnBots(Handle timer) {
@@ -447,7 +449,7 @@ public Action Event_BotDamageDealtEvent(Event event, const char[] name, bool don
 // It probably needs to use the flashbang_detonate event (so piggyback on Event_FlashDetonate).
 public Action Event_PlayerBlind(Event event, const char[] name, bool dontBroadcast) {
   if (!g_InPracticeMode) {
-    return;
+    return Plugin_Handled;
   }
 
   int userid = event.GetInt("userid");
@@ -471,6 +473,8 @@ public Action Event_PlayerBlind(Event event, const char[] name, bool dontBroadca
   if (g_ClientNoFlash[client]) {
     RequestFrame(KillFlashEffect, GetClientSerial(client));
   }
+
+  return Plugin_Handled;
 }
 
 public void KillFlashEffect(int serial) {

--- a/scripting/practicemode/commands.sp
+++ b/scripting/practicemode/commands.sp
@@ -492,6 +492,8 @@ public int ChangeMapHandler(Menu menu, MenuAction action, int param1, int param2
   } else if (action == MenuAction_End) {
     delete menu;
   }
+
+  return 0;
 }
 
 public void ChangeSettingById(const char[] id, bool setting) {

--- a/scripting/practicemode/grenade_menus.sp
+++ b/scripting/practicemode/grenade_menus.sp
@@ -236,7 +236,7 @@ public int Grenade_PlayerAndCategoryHandler(Menu menu, MenuAction action, int pa
 
     if (StrEqual(buffer, "all")) {
       GiveGrenadeMenu(client, GrenadeMenuType_OneCategory, 0, "all");
-      return;
+      return 0;
     }
 
     // split buffer from "auth name" (seperated by whitespace)
@@ -252,6 +252,8 @@ public int Grenade_PlayerAndCategoryHandler(Menu menu, MenuAction action, int pa
   } else if (action == MenuAction_End) {
     delete menu;
   }
+
+  return 0;
 }
 
 public int Grenade_NadeHandler(Menu menu, MenuAction action, int param1, int param2) {
@@ -270,6 +272,8 @@ public int Grenade_NadeHandler(Menu menu, MenuAction action, int param1, int par
   } else if (action == MenuAction_End) {
     delete menu;
   }
+
+  return 0;
 }
 
 int SortIdArrayByName(int index1, int index2, Handle array, Handle hndl) {
@@ -352,4 +356,6 @@ public Action _CountCategoryNades_Helper(const char[] ownerName, const char[] ow
     p.WriteCell(count);
     p.WriteString(cat);
   }
+
+  return Plugin_Handled;
 }

--- a/scripting/practicemode/grenade_utils.sp
+++ b/scripting/practicemode/grenade_utils.sp
@@ -372,8 +372,8 @@ public void GetGrenadeVector(const char[] auth, const char[] id, const char[] ke
   }
 }
 
-public void SetGrenadeVectors(const char[] auth, const char[] id, const float[3] origin,
-                       const float[3] angles) {
+public void SetGrenadeVectors(const char[] auth, const char[] id, const float origin[3],
+                       const float angles[3]) {
   g_UpdatedGrenadeKv = true;
   if (g_GrenadeLocationsKv.JumpToKey(auth)) {
     if (g_GrenadeLocationsKv.JumpToKey(id)) {
@@ -386,7 +386,7 @@ public void SetGrenadeVectors(const char[] auth, const char[] id, const float[3]
 }
 
 public void SetGrenadeParameters(const char[] auth, const char[] id, GrenadeType type,
-                          const float[3] grenadeOrigin, const float[3] grenadeVelocity) {
+                          const float grenadeOrigin[3], const float grenadeVelocity[3]) {
   if (!IsGrenade(type)) {
     return;
   }
@@ -453,7 +453,7 @@ public float GetClientGrenadeFloat(int id, const char[] key) {
   return GetGrenadeFloat(auth, nadeId, key);
 }
 
-public void SetClientGrenadeVectors(int id, const float[3] origin, const float[3] angles) {
+public void SetClientGrenadeVectors(int id, const float origin[3], const float angles[3]) {
   char auth[AUTH_LENGTH];
   char nadeId[GRENADE_ID_LENGTH];
   IntToString(id, nadeId, sizeof(nadeId));
@@ -461,8 +461,8 @@ public void SetClientGrenadeVectors(int id, const float[3] origin, const float[3
   SetGrenadeVectors(auth, nadeId, origin, angles);
 }
 
-public void SetClientGrenadeParameters(int id, GrenadeType type, const float[3] grenadeOrigin,
-                                const float[3] grenadeVelocity) {
+public void SetClientGrenadeParameters(int id, GrenadeType type, const float grenadeOrigin[3],
+                                const float grenadeVelocity[3]) {
   char auth[AUTH_LENGTH];
   char nadeId[GRENADE_ID_LENGTH];
   IntToString(id, nadeId, sizeof(nadeId));
@@ -644,6 +644,8 @@ public Action TranslateGrenadeHelper(const char[] ownerName, const char[] ownerA
   origin[0] += dx;
   origin[1] += dy;
   origin[2] += dz;
+
+  return Plugin_Handled;
 }
 
 public int FindNextGrenadeId(int client, int currentId) {
@@ -746,6 +748,8 @@ public Action IsCorrectionNeededHelper(const char[] ownerName, const char[] owne
     g_RepeatIdSeen = true;
   }
   g_AllIds.Push(id);
+
+  return Plugin_Handled;
 }
 
 public void CorrectGrenadeIds() {
@@ -790,6 +794,8 @@ public Action CorrectGrenadeIdsHelper(const char[] ownerName, const char[] owner
     }
   }
   g_NewKv.Rewind();
+
+  return Plugin_Handled;
 }
 
 public bool CanEditGrenade(int client, int id) {

--- a/scripting/practicemode/natives.sp
+++ b/scripting/practicemode/natives.sp
@@ -15,6 +15,8 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("PM_MessageToAll", Native_MessageToAll);
   CreateNative("PM_AddChatAlias", Native_AddChatAlias);
   RegPluginLibrary("practicemode");
+
+  return APLRes_Success;
 }
 
 public int Native_StartPracticeMode(Handle plugin, int numParams) {
@@ -85,7 +87,7 @@ public int Native_IsSettingEnabled(Handle plugin, int numParams) {
 public int Native_Message(Handle plugin, int numParams) {
   int client = GetNativeCell(1);
   if (client != 0 && (!IsClientConnected(client) || !IsClientInGame(client)))
-    return;
+    return 0;
 
   char buffer[1024];
   int bytesWritten = 0;
@@ -107,6 +109,8 @@ public int Native_Message(Handle plugin, int numParams) {
     Colorize(finalMsg, sizeof(finalMsg));
     PrintToChat(client, finalMsg);
   }
+
+  return 0;
 }
 
 public int Native_MessageToAll(Handle plugin, int numParams) {
@@ -135,6 +139,8 @@ public int Native_MessageToAll(Handle plugin, int numParams) {
       PrintToConsole(i, finalMsg);
     }
   }
+
+  return 0;
 }
 
 public int Native_AddChatAlias(Handle plugin, int numParams) {
@@ -148,4 +154,6 @@ public int Native_AddChatAlias(Handle plugin, int numParams) {
     g_ChatAliases.PushString(alias);
     g_ChatAliasesCommands.PushString(command);
   }
+
+  return 0;
 }

--- a/scripting/practicemode/settings_menu.sp
+++ b/scripting/practicemode/settings_menu.sp
@@ -50,4 +50,6 @@ public int SettingsMenuHandler(Menu menu, MenuAction action, int param1, int par
   } else if (action == MenuAction_End) {
     delete menu;
   }
+
+  return 0;
 }


### PR DESCRIPTION
Fix all the syntax errors so the plugin compiles with no errors or warnings on the latest sourcemod.

Also created the following PRs which fix the dependencies which also prevent a clean compile.

get5: https://github.com/splewis/get5/pull/964
botmimic: https://github.com/peace-maker/botmimic/pull/16

As far as I know nothing is broken, I tested it a bit but not fully.
